### PR TITLE
API 요청 관련 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.poi:poi:5.2.3'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
@@ -26,7 +26,7 @@ public class WeatherService {
      */
     public AirQualityResponse fetchAirQualityInfo() {
 
-        String serviceKey = "loLOWGHUcyqyf9PrOQeg7EzPx8ingWLA%2FSe%2FwSX%2FCZ0TUl3205I0q03halYbawbm1Vs61K%2FRVGtzHfiG3NbGrw%3D%3D";
+        String serviceKey = "loLOWGHUcyqyf9PrOQeg7EzPx8ingWLA/Se/wSX/CZ0TUl3205I0q03halYbawbm1Vs61K/RVGtzHfiG3NbGrw==";
 
         String apiURL = "https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty" +
                 "?ServiceKey=" + serviceKey +
@@ -62,7 +62,7 @@ public class WeatherService {
      */
     public WeatherInfoResponse fetchWeatherInfo() {
 
-        String serviceKey = "loLOWGHUcyqyf9PrOQeg7EzPx8ingWLA%2FSe%2FwSX%2FCZ0TUl3205I0q03halYbawbm1Vs61K%2FRVGtzHfiG3NbGrw%3D%3D";
+        String serviceKey = "loLOWGHUcyqyf9PrOQeg7EzPx8ingWLA/Se/wSX/CZ0TUl3205I0q03halYbawbm1Vs61K/RVGtzHfiG3NbGrw==";
 
         LocalDateTime currentDateTime = LocalDateTime.now().minusHours(1).withMinute(0);
 

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
@@ -34,7 +34,7 @@ public class WeatherService {
                 "&numOfRows=" + 100 +
                 "&pageNo=" + 1 +
                 "&sidoName=" + "경기" +
-                "&ver=" + 1.2;
+                "&ver=" + 1.4;
 
         String stationName = "금곡동";
 

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
@@ -83,19 +83,14 @@ public class WeatherService {
                 "&nx=" + "63" + // 성남시 중원구 상대원동 좌표
                 "&ny=" + "24";
 
-        // 장소 목록 검색 API 요청
-        WebClient client = WebClient.builder()
-                .baseUrl(apiURL)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+        RestTemplate restTemplate = new RestTemplate();
 
-        Mono<WeatherInfoPrimitiveResponse> response = client.get()
-                .uri(apiURL)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(WeatherInfoPrimitiveResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        List<WeatherInfoPrimitiveResponse.Item> items = Objects.requireNonNull(response.block())
+        ResponseEntity<WeatherInfoPrimitiveResponse> response = restTemplate.exchange(apiURL, HttpMethod.GET, entity, WeatherInfoPrimitiveResponse.class);
+        List<WeatherInfoPrimitiveResponse.Item> items = response.getBody()
                 .getResponse()
                 .getBody()
                 .getItems()

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
@@ -1,21 +1,22 @@
 package com.kyonggi.cleanup.monitor.application;
 
-import com.kyonggi.cleanup.monitor.application.dto.response.airQuality.AirQualityResponse;
 import com.kyonggi.cleanup.monitor.application.dto.response.airQuality.AirQualityPrimitiveResponse;
+import com.kyonggi.cleanup.monitor.application.dto.response.airQuality.AirQualityResponse;
 import com.kyonggi.cleanup.monitor.application.dto.response.weather.WeatherCode;
 import com.kyonggi.cleanup.monitor.application.dto.response.weather.WeatherInfoPrimitiveResponse;
 import com.kyonggi.cleanup.monitor.application.dto.response.weather.WeatherInfoResponse;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 
 @Service
 public class WeatherService {
@@ -37,19 +38,14 @@ public class WeatherService {
 
         String stationName = "금곡동";
 
-        // 장소 목록 검색 API 요청
-        WebClient client = WebClient.builder()
-                .baseUrl(apiURL)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+        RestTemplate restTemplate = new RestTemplate();
 
-        Mono<AirQualityPrimitiveResponse> response = client.get()
-                .uri(apiURL)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(AirQualityPrimitiveResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        List<AirQualityPrimitiveResponse.ResponseBody.ResponseBodyItems.Item> items = Objects.requireNonNull(response.block())
+        ResponseEntity<AirQualityPrimitiveResponse> response = restTemplate.exchange(apiURL, HttpMethod.GET, entity, AirQualityPrimitiveResponse.class);
+        List<AirQualityPrimitiveResponse.ResponseBody.ResponseBodyItems.Item> items = response.getBody()
                 .getResponse()
                 .getBody()
                 .getItems();

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/WeatherService.java
@@ -36,7 +36,8 @@ public class WeatherService {
                 "&sidoName=" + "경기" +
                 "&ver=" + 1.4;
 
-        String stationName = "금곡동";
+        String stationName1 = "상대원동";
+        String stationName2 = "금곡동";
 
         RestTemplate restTemplate = new RestTemplate();
 
@@ -51,10 +52,16 @@ public class WeatherService {
                 .getItems();
 
         return items.stream()
-                .filter(item -> item.getStationName().equals(stationName))
+                .filter(item -> item.getStationName().equals(stationName1))
                 .map(AirQualityResponse::of)
                 .findFirst()
-                .orElseThrow(() -> new NoSuchElementException("해당하는 관측소명이 존재하지 않습니다."));
+                .orElseGet(() -> items.stream()
+                        .filter(item -> item.getStationName().equals(stationName2))
+                        .map(AirQualityResponse::of)
+                        .findFirst()
+                        .orElseThrow(() -> new NoSuchElementException("해당하는 관측소명이 존재하지 않습니다."))
+                );
+
     }
 
     /*

--- a/src/main/java/com/kyonggi/cleanup/monitor/application/dto/response/airQuality/AirQualityResponse.java
+++ b/src/main/java/com/kyonggi/cleanup/monitor/application/dto/response/airQuality/AirQualityResponse.java
@@ -13,6 +13,7 @@ public class AirQualityResponse {
     private LocalDateTime dateTime;
     private String sidoName; // 시도 이름 -> ex) 서울 부산 대구 인천 광주 대전 울산 경기 강원
     private String mangName; // 측정망 정보 -> 도시대기, 도로변대기, 국가배경농도, 교외대기, 항만
+    private String stationName;
 
     /*
     value: 농도
@@ -59,6 +60,7 @@ public class AirQualityResponse {
                 .dateTime(LocalDateTime.parse(response.getDataTime(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .sidoName(response.getSidoName())
                 .mangName(response.getMangName())
+                .stationName(response.getStationName())
                 .pm10Value(response.getPm10Value())
                 .pm10Value24h(response.getPm10Value24())
                 .pm10Grade1h(response.getPm10Grade1h())


### PR DESCRIPTION
## 🚀 Summary
> #12 
>
> 1. 공공 API 요청 과정에서 Spring Web Flux의 `WebClient` 가 문제를 일으키는 것으로 확인하여 
> `WebClient` 대신 `RestTemplate` 을 사용하여 요청을 진행하도록 변경하였습니다.
> 
> 2. 대기오염정보 필터링 과정에서 기존 "금곡동"의 정보를 확정적으로 반환하던 로직을 "상대원동" 정보를 우선적으로 탐색한 후, 
> 존재하지 않는다면 2차적으로 "금곡동"의 정보를 반환할 수 있도록 변경하였습니다.
> 
> 3. 대기오염정보 응답 dto에서 어느 지역의 정보를 반환하는지 확인할 수 있도록 측정소 필드를 추가하였습니다.

##  🙋🏻 More
> 실시간 날씨 API가 지속적으로 "-998", "-999" 등의 이상값을 반환하고 있으나, 이는 로직의 문제가 아닌 공공 API 측의 자체적인
> 측정불량 때문인 것으로 보입니다. 추후 개선사항을 찾는다면 반영하겠습니다.